### PR TITLE
Update to Minecraft 1.21.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '1.2-SNAPSHOT'
+    id 'fabric-loom' version '1.7.3'
     id 'maven-publish'
 }
 
@@ -35,11 +35,11 @@ dependencies {
     modImplementation(fabricApi.module("fabric-api-base", project.fabric_version))
     modImplementation(fabricApi.module("fabric-block-view-api-v2", project.fabric_version))
     modImplementation(fabricApi.module("fabric-rendering-fluids-v1", project.fabric_version))
-    modImplementation("net.fabricmc.fabric-api:fabric-rendering-data-attachment-v1:0.3.38+73761d2e9a")
+    modImplementation(fabricApi.module("fabric-rendering-data-attachment-v1", project.fabric_version))
     modImplementation(fabricApi.module("fabric-resource-loader-v0", project.fabric_version))
 
-    modImplementation "maven.modrinth:sodium:mc1.20.2-0.5.3"
-    modImplementation "maven.modrinth:iris:1.6.9+1.20.2"
+    modImplementation "maven.modrinth:sodium:mc1.21.1-0.6.13-fabric"
+    modImplementation "maven.modrinth:iris:1.8.8+1.21.1-fabric"
 
     modRuntimeOnly 'org.anarres:jcpp:1.4.14'
     modRuntimeOnly 'io.github.douira:glsl-transformer:2.0.0-pre13'
@@ -56,7 +56,7 @@ processResources {
     }
 }
 
-def targetJavaVersion = 17
+def targetJavaVersion = 21
 tasks.withType(JavaCompile).configureEach {
     // ensure that the encoding is set to UTF-8, no matter what the system default is
     // this fixes some edge cases with special characters not displaying correctly

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,12 +2,12 @@
 org.gradle.jvmargs=-Xmx4G
 # Fabric Properties
 # check these on https://modmuss50.me/fabric.html
-minecraft_version=1.20.2
-yarn_mappings=1.20.2+build.1
-loader_version=0.14.21
+minecraft_version=1.21.1
+yarn_mappings=1.21.1+build.3
+loader_version=0.16.12
 
 #Fabric api
-fabric_version=0.88.5+1.20.2
+fabric_version=0.115.4+1.21.1
 # Mod Properties
 mod_version=0.0.4-pre-alpha
 maven_group=me.cortex

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This PR updates the project to Minecraft 1.21.1, Fabric API 0.115.4, Sodium 0.6.13, and Iris 1.8.8. It also updates the Gradle wrapper to 8.8 and sets the Java target version to 21, which is required for Minecraft 1.21.1.